### PR TITLE
DefaultValue instance of Either is ill defined

### DIFF
--- a/src/Mantine/Core/Common.purs
+++ b/src/Mantine/Core/Common.purs
@@ -2,7 +2,7 @@ module Mantine.Core.Common
   ( MantineColor(..)
   , DimmedOrColor(..)
   , MantineSize(..)
-  , MantineNumberSize
+  , MantineNumberSize(..)
   , MantineNumberSizeImpl
   , Orientation(..)
   , Radius(..)
@@ -15,7 +15,7 @@ module Mantine.Core.Common
   , JustifyContent(..)
   , Milliseconds
   , Pixels
-  , Dimension
+  , Dimension(..)
   , DimensionImpl
   , MantineTransition(..)
   , MantineTransitionTimingFunction(..)
@@ -52,7 +52,7 @@ import React.Basic.Emotion (Style)
 import React.Basic.Hooks (JSX)
 import Record (merge, union)
 import Type.Row (class Nub, type (+))
-import Untagged.Union (type (|+|))
+import Untagged.Union (type (|+|), asOneOf)
 
 data MantineColor
   = Dark
@@ -236,7 +236,15 @@ data MantineSize
   | Large
   | ExtraLarge
 
-type MantineNumberSize = Either Number MantineSize
+data MantineNumberSize
+  = Custom Number
+  | Preset MantineSize
+
+instance ToFFI MantineNumberSize MantineNumberSizeImpl where
+  toNative = case _ of
+    Custom n -> asOneOf n
+    Preset s -> asOneOf (toNative s)
+
 type MantineNumberSizeImpl = Number |+| String
 
 data Radius
@@ -613,7 +621,13 @@ justifyContentNative = case _ of
 type Milliseconds = Number
 type Pixels = Number
 
-type Dimension = Either Number String
+data Dimension = Pixels Number | Dimension String
+
+instance ToFFI Dimension DimensionImpl where
+  toNative = case _ of
+    Pixels    p -> asOneOf p
+    Dimension n -> asOneOf n
+
 type DimensionImpl = Number |+| String
 
 data MantineTransition

--- a/src/Mantine/Core/Feedback/Skeleton.purs
+++ b/src/Mantine/Core/Feedback/Skeleton.purs
@@ -29,7 +29,7 @@ defaultSkeletonProps :: SkeletonProps
 defaultSkeletonProps =
   defaultThemingProps
     { animate: true
-    , height:  pure "auto"
+    , height:  Dimension "auto"
     , visible: true
     } `union` defaultValue
 

--- a/src/Mantine/Core/Layout/Grid.purs
+++ b/src/Mantine/Core/Layout/Grid.purs
@@ -36,7 +36,7 @@ defaultGridProps =
   defaultThemingProps
     { align:    AlignContentStretch
     , columns:  12
-    , gutter:   pure Medium
+    , gutter:   Preset Medium
     , justify:  JustifyContentFlexStart
     } `union` defaultValue
 

--- a/src/Mantine/Core/Miscellaneous/Paper.purs
+++ b/src/Mantine/Core/Miscellaneous/Paper.purs
@@ -26,7 +26,7 @@ type PaperProps =
 defaultPaperProps :: PaperProps
 defaultPaperProps =
   defaultThemingProps
-    { radius: pure Small
+    { radius: Preset Small
     } `union` defaultValue
 
 type PaperPropsImpl =

--- a/src/Mantine/Core/Navigation/Pagination.purs
+++ b/src/Mantine/Core/Navigation/Pagination.purs
@@ -42,9 +42,9 @@ defaultPaginationProps :: PaginationProps
 defaultPaginationProps =
   defaultThemingProps
     { boundaries:   PageCount 1
-    , radius:       pure Small
+    , radius:       Preset Small
     , siblings:     PageCount 1
-    , size:         pure Medium
+    , size:         Preset Medium
     , total:        PageCount 1
     , withControls: true
     } `union` defaultValue

--- a/src/Mantine/Core/Overlays/Tooltip.purs
+++ b/src/Mantine/Core/Overlays/Tooltip.purs
@@ -115,7 +115,7 @@ defaultTooltipProps =
     , openDelay:        0.0
     , position:         TooltipPositionTop
     , transition:       TransitionFade
-    , width:            pure (pure "auto")
+    , width:            pure (Dimension "auto")
     } `union` defaultValue
 
 type TooltipPropsImpl = ThemingPropsImpl (TooltipPropsBaseImplRow + TooltipPropsImplRow)

--- a/src/Mantine/Core/Typography/Table.purs
+++ b/src/Mantine/Core/Typography/Table.purs
@@ -32,9 +32,9 @@ type TableProps =
 defaultTableProps :: TableProps
 defaultTableProps =
   defaultThemingProps
-    { horizontalSpacing: Right ExtraSmall
-    , fontSize:          Right Small
-    , verticalSpacing:   Left 7.0
+    { horizontalSpacing: Preset ExtraSmall
+    , fontSize:          Preset Small
+    , verticalSpacing:   Custom 7.0
     } `union` defaultValue
 
 data TableCaptionSide


### PR DESCRIPTION
Implementation looks like this:
```purescript
instance DefaultValue e => DefaultValue (Either e w) where
  defaultValue = Left defaultValue
```

This is kind of fine and makes sense but it's a bit opinionated and it's not the behavior we want want representation is disjunction as we do for some types here.

Let's drop those Eithers from the Common module and use proper ADTs. It's also a better API as it names constructors and we don't suffer from boolean blindness.