### PR TITLE
Better helpers

### DIFF
--- a/src/Mantine/Core/Buttons/ActionIcon.purs
+++ b/src/Mantine/Core/Buttons/ActionIcon.purs
@@ -38,7 +38,7 @@ defaultActionIconProps icon =
   defaultThemingProps
     { icon
     , onClick: handler_ (pure unit)
-    } `union` defaultValue
+    }
 
 type ActionIconPropsImpl = ThemingPropsImpl ActionIconPropsImplRow
 

--- a/src/Mantine/Core/Buttons/ActionIcon.purs
+++ b/src/Mantine/Core/Buttons/ActionIcon.purs
@@ -9,9 +9,7 @@ module Mantine.Core.Buttons.ActionIcon
   , ActionIconPropsImplRow
   ) where
 
-import Prelude (pure, unit)
 import Mantine.Core.Prelude
-import React.Basic.Events (EventHandler, handler_)
 import React.Icons (icon_)
 import React.Icons.Types (ReactIcon)
 

--- a/src/Mantine/Core/Buttons/Button.purs
+++ b/src/Mantine/Core/Buttons/Button.purs
@@ -14,7 +14,7 @@ module Mantine.Core.Buttons.Button
   , ButtonVariant(..)
   ) where
 
-import Prelude hiding (bind)
+import Prelude (class Show)
 import Data.Generic.Rep (class Generic)
 import Data.Show.Generic (genericShow)
 import Mantine.Core.Prelude

--- a/src/Mantine/Core/Buttons/Button.purs
+++ b/src/Mantine/Core/Buttons/Button.purs
@@ -164,10 +164,7 @@ unstyledButton :: (UnstyledButtonProps -> UnstyledButtonProps) -> JSX
 unstyledButton = mkComponentWithDefault unstyledButtonComponent defaultUnstyledButtonProps
 
 defaultUnstyledButtonProps :: UnstyledButtonProps
-defaultUnstyledButtonProps =
-  defaultThemingProps
-    { onClick: handler_ (pure unit)
-    } `union` defaultValue
+defaultUnstyledButtonProps = defaultThemingProps { onClick: handler_ (pure unit) }
 
 type UnstyledButtonProps =
   ThemingProps

--- a/src/Mantine/Core/DataDisplay/Accordion.purs
+++ b/src/Mantine/Core/DataDisplay/Accordion.purs
@@ -30,10 +30,7 @@ foreign import accordionComponent :: ReactComponent (AccordionPropsImpl String)
 foreign import multipleAccordionComponent :: ReactComponent (AccordionPropsImpl (Array String))
 
 defaultAccordionProps :: forall accordionValue. AccordionProps accordionValue
-defaultAccordionProps =
-  defaultThemingProps
-    { radius: Preset Small
-    } `union` defaultValue
+defaultAccordionProps = defaultThemingProps { radius: Preset Small }
 
 type AccordionProps accordionValue =
   ThemingProps

--- a/src/Mantine/Core/DataDisplay/Avatar.purs
+++ b/src/Mantine/Core/DataDisplay/Avatar.purs
@@ -46,7 +46,7 @@ defaultAvatarProps =
   defaultThemingProps
     { size:   Preset Medium
     , radius: Preset Small
-    } `union` defaultValue
+    }
 
 type AvatarPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/DataDisplay/Avatar.purs
+++ b/src/Mantine/Core/DataDisplay/Avatar.purs
@@ -7,7 +7,6 @@ module Mantine.Core.DataDisplay.Avatar
   , AvatarGroupProps
   ) where
 
-import Prelude (pure)
 import Mantine.Core.Prelude
 
 avatar :: (AvatarProps -> AvatarProps) -> JSX

--- a/src/Mantine/Core/DataDisplay/BackgroundImage.purs
+++ b/src/Mantine/Core/DataDisplay/BackgroundImage.purs
@@ -26,7 +26,7 @@ defaultBackgroundImageProps src =
   defaultThemingProps
     { radius: Preset Small
     , src
-    } `union` defaultValue
+    }
 
 type BackgroundImagePropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/DataDisplay/BackgroundImage.purs
+++ b/src/Mantine/Core/DataDisplay/BackgroundImage.purs
@@ -4,7 +4,6 @@ module Mantine.Core.DataDisplay.BackgroundImage
   , BackgroundImageProps
   ) where
 
-import Prelude (identity, (<<<))
 import Mantine.Core.Prelude
 
 backgroundImage :: String -> (BackgroundImageProps -> BackgroundImageProps) -> JSX

--- a/src/Mantine/Core/DataDisplay/Badge.purs
+++ b/src/Mantine/Core/DataDisplay/Badge.purs
@@ -50,7 +50,7 @@ defaultBadgeProps =
   defaultThemingProps
     { size:   Medium
     , radius: Preset ExtraLarge
-    } `union` defaultValue
+    }
 
 type BadgePropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/DataDisplay/Badge.purs
+++ b/src/Mantine/Core/DataDisplay/Badge.purs
@@ -5,7 +5,6 @@ module Mantine.Core.DataDisplay.Badge
   , BadgeVariant(..)
   ) where
 
-import Prelude ((=<<), pure)
 import Mantine.Core.Prelude
 
 badge :: (BadgeProps -> BadgeProps) -> JSX

--- a/src/Mantine/Core/DataDisplay/Card.purs
+++ b/src/Mantine/Core/DataDisplay/Card.purs
@@ -22,10 +22,7 @@ type CardProps =
     )
 
 defaultCardProps :: CardProps
-defaultCardProps =
-  defaultThemingProps
-    { radius: Preset Small
-    } `union` defaultValue
+defaultCardProps = defaultThemingProps { radius: Preset Small }
 
 type CardPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/DataDisplay/ColorSwatch.purs
+++ b/src/Mantine/Core/DataDisplay/ColorSwatch.purs
@@ -14,8 +14,7 @@ colorSwatch_ c = colorSwatch c identity
 foreign import colorSwatchComponent :: ReactComponent ColorSwatchPropsImpl
 
 defaultColorSwatch :: MantineColor -> ColorSwatchProps
-defaultColorSwatch color =
-  defaultThemingProps { color } `union` defaultValue
+defaultColorSwatch color = defaultThemingProps { color }
 
 type ColorSwatchProps =
   ThemingProps (

--- a/src/Mantine/Core/DataDisplay/ThemeIcon.purs
+++ b/src/Mantine/Core/DataDisplay/ThemeIcon.purs
@@ -25,7 +25,7 @@ defaultThemeIconProps =
   defaultThemingProps
     { size:   Preset Medium
     , radius: Preset Small
-    } `union` defaultValue
+    }
 
 type ThemeIconPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Feedback/Alert.purs
+++ b/src/Mantine/Core/Feedback/Alert.purs
@@ -49,7 +49,7 @@ defaultAlertProps =
     { children: mempty :: JSX
     , closable: NotClosable
     , variant:  AlertVariantLight
-    } `union` defaultValue
+    }
 
 type AlertPropsImpl = ThemingPropsImpl (CloseProps + AlertPropsRowImpl)
 

--- a/src/Mantine/Core/Feedback/Alert.purs
+++ b/src/Mantine/Core/Feedback/Alert.purs
@@ -6,7 +6,6 @@ module Mantine.Core.Feedback.Alert
   , AlertVariant(..)
   ) where
 
-import Prelude
 import Mantine.Core.Prelude
 
 alert :: (AlertProps -> AlertProps) -> JSX

--- a/src/Mantine/Core/Feedback/Loader.purs
+++ b/src/Mantine/Core/Feedback/Loader.purs
@@ -5,7 +5,6 @@ module Mantine.Core.Feedback.Loader
   , LoaderVariant(..)
   ) where
 
-import Prelude
 import Mantine.Core.Prelude
 
 loader :: (LoaderProps -> LoaderProps) -> JSX

--- a/src/Mantine/Core/Feedback/Notification.purs
+++ b/src/Mantine/Core/Feedback/Notification.purs
@@ -32,7 +32,7 @@ defaultNotificationProps =
    defaultThemingProps
      { children: mempty
      , onClose: pure unit
-     } `union` defaultValue
+     }
 
 type NotificationPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Feedback/Notification.purs
+++ b/src/Mantine/Core/Feedback/Notification.purs
@@ -4,7 +4,6 @@ module Mantine.Core.Feedback.Notification
   , NotificationProps
   ) where
 
-import Prelude
 import Mantine.Core.Prelude
 
 notification :: (NotificationProps -> NotificationProps) -> JSX

--- a/src/Mantine/Core/Feedback/Skeleton.purs
+++ b/src/Mantine/Core/Feedback/Skeleton.purs
@@ -31,7 +31,7 @@ defaultSkeletonProps =
     { animate: true
     , height:  Dimension "auto"
     , visible: true
-    } `union` defaultValue
+    }
 
 type SkeletonPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Feedback/Skeleton.purs
+++ b/src/Mantine/Core/Feedback/Skeleton.purs
@@ -4,7 +4,6 @@ module Mantine.Core.Feedback.Skeleton
   , SkeletonProps
   ) where
 
-import Prelude
 import Mantine.Core.Prelude
 
 skeleton :: (SkeletonProps -> SkeletonProps) -> JSX

--- a/src/Mantine/Core/Inputs/Checkbox.purs
+++ b/src/Mantine/Core/Inputs/Checkbox.purs
@@ -8,7 +8,6 @@ module Mantine.Core.Inputs.Checkbox
   , CheckboxGroupProps
   ) where
 
-import Prelude hiding (bind)
 import Mantine.Core.Prelude
 
 checkbox :: (CheckboxProps -> CheckboxProps) -> JSX

--- a/src/Mantine/Core/Inputs/Chip.purs
+++ b/src/Mantine/Core/Inputs/Chip.purs
@@ -12,7 +12,7 @@ module Mantine.Core.Inputs.Chip
   , ChipGroupPosition(..)
   ) where
 
-import Prelude (class Show, Unit, pure)
+import Prelude (class Show)
 import Data.Array (last)
 import Data.Generic.Rep (class Generic)
 import Data.Maybe (maybe)

--- a/src/Mantine/Core/Inputs/Chip.purs
+++ b/src/Mantine/Core/Inputs/Chip.purs
@@ -44,7 +44,7 @@ defaultChipProps =
   defaultThemingProps
     { size:   Small
     , radius: RadiusPreset ExtraLarge
-    } `union` defaultValue
+    }
 
 type ChipPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Inputs/MultiSelect.purs
+++ b/src/Mantine/Core/Inputs/MultiSelect.purs
@@ -9,7 +9,6 @@ module Mantine.Core.Inputs.MultiSelect
   , module Mantine.Core.Inputs.Input
   ) where
 
-import Prelude (Unit, map, pure, ($), (<$>), (<<<), (=<<))
 import Data.Maybe (fromMaybe, maybe)
 import Effect.Uncurried (mkEffectFn1)
 import Mantine.Core.Prelude

--- a/src/Mantine/Core/Inputs/Radio.purs
+++ b/src/Mantine/Core/Inputs/Radio.purs
@@ -31,10 +31,7 @@ type RadioProps =
     )
 
 defaultRadioProps :: RadioProps
-defaultRadioProps =
-  defaultThemingProps
-    { size: Small
-    } `union` defaultValue
+defaultRadioProps = defaultThemingProps { size: Small }
 
 type RadioPropsImpl =
   ThemingPropsImpl
@@ -89,7 +86,7 @@ defaultRadioGroupProps =
   defaultThemingProps
     { orientation:  Horizontal
     , size:         Small
-    } `union` defaultValue
+    }
 
 type RadioGroupPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Inputs/SegmentedControl.purs
+++ b/src/Mantine/Core/Inputs/SegmentedControl.purs
@@ -5,7 +5,6 @@ module Mantine.Core.Inputs.SegmentedControl
   , SegmentedControlOrientation(..)
   ) where
 
-import Prelude (Unit, (<<<))
 import Mantine.Core.Prelude
 
 segmentedControl :: (SegmentedControlProps -> SegmentedControlProps) -> JSX

--- a/src/Mantine/Core/Inputs/Select.purs
+++ b/src/Mantine/Core/Inputs/Select.purs
@@ -9,7 +9,6 @@ module Mantine.Core.Inputs.Select
   , module Mantine.Core.Inputs.Input
   ) where
 
-import Prelude ((<$>))
 import Data.Maybe (maybe)
 import Effect.Uncurried (mkEffectFn1)
 import Mantine.Core.Prelude

--- a/src/Mantine/Core/Inputs/Select.purs
+++ b/src/Mantine/Core/Inputs/Select.purs
@@ -104,7 +104,7 @@ defaultSelectProps =
   defaultThemingProps
     { onDropdownClose: pure unit
     , onDropdownOpen:  pure unit
-    } `union` defaultValue
+    }
 
 type SelectPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Inputs/Slider.purs
+++ b/src/Mantine/Core/Inputs/Slider.purs
@@ -12,7 +12,6 @@ module Mantine.Core.Inputs.Slider
   , ScaleFunction(..)
   ) where
 
-import Prelude
 import Mantine.Core.Prelude
 
 slider :: (SliderProps -> SliderProps) -> JSX

--- a/src/Mantine/Core/Inputs/Switch.purs
+++ b/src/Mantine/Core/Inputs/Switch.purs
@@ -9,7 +9,6 @@ module Mantine.Core.Inputs.Switch
   , SwitchGroupProps
   ) where
 
-import Prelude (Unit, (<$>), (<<<))
 import Mantine.Core.Prelude
 
 switch :: (SwitchProps -> SwitchProps) -> JSX

--- a/src/Mantine/Core/Layout/AppShell.purs
+++ b/src/Mantine/Core/Layout/AppShell.purs
@@ -21,8 +21,6 @@ module Mantine.Core.Layout.AppShell
   , Rules(..)
   ) where
 
-import Prelude (map, (<$>))
-import Foreign.Object (Object, fromFoldable)
 import Mantine.Core.Prelude
 
 appShell :: (AppShellProps -> AppShellProps) -> JSX

--- a/src/Mantine/Core/Layout/Container.purs
+++ b/src/Mantine/Core/Layout/Container.purs
@@ -5,7 +5,6 @@ module Mantine.Core.Layout.Container
   , ContainerSizes
   ) where
 
-import Prelude
 import Data.Bifunctor (lmap)
 import Mantine.Core.Prelude
 

--- a/src/Mantine/Core/Layout/Grid.purs
+++ b/src/Mantine/Core/Layout/Grid.purs
@@ -9,7 +9,6 @@ module Mantine.Core.Layout.Grid
   , GridColSpan(..)
   ) where
 
-import Prelude
 import Data.Int (toNumber)
 import Mantine.Core.Prelude
 

--- a/src/Mantine/Core/Layout/Grid.purs
+++ b/src/Mantine/Core/Layout/Grid.purs
@@ -38,7 +38,7 @@ defaultGridProps =
     , columns:  12
     , gutter:   Preset Medium
     , justify:  JustifyContentFlexStart
-    } `union` defaultValue
+    }
 
 type GridPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Layout/Group.purs
+++ b/src/Mantine/Core/Layout/Group.purs
@@ -25,10 +25,7 @@ type GroupProps =
     )
 
 defaultGroupProps :: GroupProps
-defaultGroupProps =
-  defaultThemingProps
-    { noWrap: true
-    } `union` defaultValue
+defaultGroupProps = defaultThemingProps { noWrap: true }
 
 type GroupPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Miscellaneous/Collapse.purs
+++ b/src/Mantine/Core/Miscellaneous/Collapse.purs
@@ -45,7 +45,7 @@ defaultCollapseProps =
     , onTransitionEnd:          pure unit
     , transitionDuration:       200.0
     , transitionTimingFunction: TransitionTimingEase
-    } `union` defaultValue
+    }
 
 type CollapsePropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Miscellaneous/Collapse.purs
+++ b/src/Mantine/Core/Miscellaneous/Collapse.purs
@@ -5,7 +5,6 @@ module Mantine.Core.Miscellaneous.Collapse
   , CollapseAxis(..)
   ) where
 
-import Prelude (Unit, unit, pure, (<<<))
 import Mantine.Core.Prelude
 
 collapse :: (CollapseProps -> CollapseProps) -> JSX

--- a/src/Mantine/Core/Miscellaneous/Divider.purs
+++ b/src/Mantine/Core/Miscellaneous/Divider.purs
@@ -28,10 +28,7 @@ type DividerProps =
     )
 
 defaultDividerProps :: DividerProps
-defaultDividerProps =
-  defaultThemingProps
-    { orientation: Horizontal
-    } `union` defaultValue
+defaultDividerProps = defaultThemingProps { orientation: Horizontal }
 
 data DividerLabelPosition
   = DividerLabelPositionLeft

--- a/src/Mantine/Core/Miscellaneous/Divider.purs
+++ b/src/Mantine/Core/Miscellaneous/Divider.purs
@@ -6,7 +6,6 @@ module Mantine.Core.Miscellaneous.Divider
   , DividerVariant(..)
   ) where
 
-import Prelude (identity)
 import Mantine.Core.Prelude
 
 divider :: (DividerProps -> DividerProps) -> JSX

--- a/src/Mantine/Core/Miscellaneous/Paper.purs
+++ b/src/Mantine/Core/Miscellaneous/Paper.purs
@@ -24,10 +24,7 @@ type PaperProps =
     )
 
 defaultPaperProps :: PaperProps
-defaultPaperProps =
-  defaultThemingProps
-    { radius: Preset Small
-    } `union` defaultValue
+defaultPaperProps = defaultThemingProps { radius: Preset Small }
 
 type PaperPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Miscellaneous/Paper.purs
+++ b/src/Mantine/Core/Miscellaneous/Paper.purs
@@ -4,7 +4,6 @@ module Mantine.Core.Miscellaneous.Paper
   , PaperProps
   ) where
 
-import Prelude
 import Mantine.Core.Prelude
 
 paper :: (PaperProps -> PaperProps) -> JSX

--- a/src/Mantine/Core/Miscellaneous/ScrollArea.purs
+++ b/src/Mantine/Core/Miscellaneous/ScrollArea.purs
@@ -6,7 +6,6 @@ module Mantine.Core.Miscellaneous.ScrollArea
   , ScrollbarType(..)
   ) where
 
-import Prelude (Unit)
 import Mantine.Core.Prelude
 import Web.HTML.HTMLDivElement (HTMLDivElement)
 

--- a/src/Mantine/Core/Navigation/Burger.purs
+++ b/src/Mantine/Core/Navigation/Burger.purs
@@ -3,7 +3,6 @@ module Mantine.Core.Navigation.Burger
   , BurgerProps
   ) where
 
-import Prelude (pure, unit)
 import Mantine.Core.Prelude
 
 burger :: (BurgerProps -> BurgerProps) -> JSX

--- a/src/Mantine/Core/Navigation/Burger.purs
+++ b/src/Mantine/Core/Navigation/Burger.purs
@@ -21,10 +21,7 @@ type BurgerProps =
     )
 
 defaultBurgerProps :: BurgerProps
-defaultBurgerProps =
-  defaultThemingProps
-    { onClick: handler_ (pure unit)
-    } `union` defaultValue
+defaultBurgerProps = defaultThemingProps { onClick: handler_ (pure unit) }
 
 type BurgerPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Navigation/NavLink.purs
+++ b/src/Mantine/Core/Navigation/NavLink.purs
@@ -4,7 +4,6 @@ module Mantine.Core.Navigation.NavLink
   , NavLinkVariant(..)
   ) where
 
-import Prelude
 import Mantine.Core.Prelude
 
 navLink :: (NavLinkProps -> NavLinkProps) -> JSX

--- a/src/Mantine/Core/Navigation/NavLink.purs
+++ b/src/Mantine/Core/Navigation/NavLink.purs
@@ -39,7 +39,7 @@ defaultNavLinkProps =
     { label:   mempty :: JSX
     , onClick: handler_ (pure unit)
     , variant: NavLinkLight
-    } `union` defaultValue
+    }
 
 type NavLinkPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Navigation/Pagination.purs
+++ b/src/Mantine/Core/Navigation/Pagination.purs
@@ -47,7 +47,7 @@ defaultPaginationProps =
     , size:         Preset Medium
     , total:        PageCount 1
     , withControls: true
-    } `union` defaultValue
+    }
 
 newtype Page = Page Int
 

--- a/src/Mantine/Core/Navigation/Pagination.purs
+++ b/src/Mantine/Core/Navigation/Pagination.purs
@@ -6,7 +6,7 @@ module Mantine.Core.Navigation.Pagination
   , PaginationProps
   ) where
 
-import Prelude
+import Prelude (class Eq, class Ord, class Show)
 import Data.Int (floor, toNumber)
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Mantine.Core.Prelude

--- a/src/Mantine/Core/Navigation/Tabs.purs
+++ b/src/Mantine/Core/Navigation/Tabs.purs
@@ -19,7 +19,6 @@ module Mantine.Core.Navigation.Tabs
   , TabPanelProps
   ) where
 
-import Prelude (Unit)
 import Mantine.Core.Prelude
 
 tabs :: (TabsProps -> TabsProps) -> JSX

--- a/src/Mantine/Core/Overlays/Affix.purs
+++ b/src/Mantine/Core/Overlays/Affix.purs
@@ -31,10 +31,7 @@ type AffixPosition =
   }
 
 defaultAffixProps :: AffixProps
-defaultAffixProps =
-  defaultThemingProps
-    { withinPortal: true
-    } `union` defaultValue
+defaultAffixProps = defaultThemingProps { withinPortal: true }
 
 type AffixPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Overlays/Dialog.purs
+++ b/src/Mantine/Core/Overlays/Dialog.purs
@@ -37,7 +37,7 @@ type DialogPosition =
   }
 
 defaultDialogProps :: DialogProps
-defaultDialogProps = defaultThemingProps { onClose: pure unit } `union` defaultValue
+defaultDialogProps = defaultThemingProps { onClose: pure unit }
 
 type DialogPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Overlays/Dialog.purs
+++ b/src/Mantine/Core/Overlays/Dialog.purs
@@ -4,7 +4,6 @@ module Mantine.Core.Overlays.Dialog
   , DialogPosition
   ) where
 
-import Prelude (Unit, pure, unit)
 import Mantine.Core.Prelude
 
 dialog :: (DialogProps -> DialogProps) -> JSX

--- a/src/Mantine/Core/Overlays/Drawer.purs
+++ b/src/Mantine/Core/Overlays/Drawer.purs
@@ -4,7 +4,6 @@ module Mantine.Core.Overlays.Drawer
   , DrawerPosition(..)
   ) where
 
-import Prelude (Unit, pure, unit)
 import Mantine.Core.Prelude
 import Web.HTML (HTMLElement)
 

--- a/src/Mantine/Core/Overlays/Drawer.purs
+++ b/src/Mantine/Core/Overlays/Drawer.purs
@@ -74,8 +74,7 @@ type DrawerPropsImpl =
     )
 
 defaultDrawerProps :: DrawerProps
-defaultDrawerProps = defaultThemingProps
-  { onClose: pure unit } `union` defaultValue
+defaultDrawerProps = defaultThemingProps { onClose: pure unit }
 
 data DrawerPosition = Bottom | Left | Right | Top
 

--- a/src/Mantine/Core/Overlays/Hovering.purs
+++ b/src/Mantine/Core/Overlays/Hovering.purs
@@ -33,7 +33,7 @@ defaultHoverCardProps =
   defaultThemingProps
     { onClose: pure unit
     , onOpen:  pure unit
-    } `union` defaultValue
+    }
 
 type HoverCardProps =
   HoveringCommons
@@ -82,7 +82,7 @@ defaultPopoverProps =
     , onClose:             pure unit
     , onOpen:              pure unit
     , withRoles:           true
-    } `union` defaultValue
+    }
 
 type PopoverProps =
   HoveringCommons

--- a/src/Mantine/Core/Overlays/Hovering.purs
+++ b/src/Mantine/Core/Overlays/Hovering.purs
@@ -19,7 +19,6 @@ module Mantine.Core.Overlays.Hovering
   , HoverPopupType(..)
   ) where
 
-import Prelude
 import Mantine.Core.Prelude
 import React.Basic.DOM as DOM
 
@@ -247,14 +246,14 @@ type HoveringTargetProps =
     , refProps  :: Maybe String
     )
 
-data HoverPopupType = Dialog | Custom String
+data HoverPopupType = HoverPopupTypeDialog | HoverPopupTypeCustom String
 
-instance DefaultValue HoverPopupType where defaultValue = Dialog
+instance DefaultValue HoverPopupType where defaultValue = HoverPopupTypeDialog
 
 instance ToFFI HoverPopupType String where
   toNative = case _ of
-    Dialog -> "dialog"
-    Custom s -> s
+    HoverPopupTypeDialog -> "dialog"
+    HoverPopupTypeCustom s -> s
 
 defaultHoveringTargetProps :: HoveringTargetProps
 defaultHoveringTargetProps = defaultThemingProps_

--- a/src/Mantine/Core/Overlays/Menu.purs
+++ b/src/Mantine/Core/Overlays/Menu.purs
@@ -78,7 +78,7 @@ defaultMenuProps =
     , onClose:             pure unit
     , onOpen:              pure unit
     -- , shadow -- TODO
-    } `union` defaultValue
+    }
 
 type MenuPropsImpl =
   ThemingPropsImpl
@@ -258,7 +258,7 @@ defaultMenuItemProps :: MenuItemProps
 defaultMenuItemProps =
   defaultThemingProps
     { onClick: pure unit
-    } `union` defaultValue
+    }
 
 type MenuItemPropsImpl =
   ThemingPropsImpl

--- a/src/Mantine/Core/Overlays/Menu.purs
+++ b/src/Mantine/Core/Overlays/Menu.purs
@@ -18,7 +18,6 @@ module Mantine.Core.Overlays.Menu
   , menuDivider
   ) where
 
-import Prelude
 import Mantine.Core.Prelude
 import React.Basic (element)
 import React.Basic.DOM.Events (preventDefault)

--- a/src/Mantine/Core/Overlays/Modal.purs
+++ b/src/Mantine/Core/Overlays/Modal.purs
@@ -5,7 +5,6 @@ module Mantine.Core.Overlays.Modal
   , ModalOverflow(..)
   ) where
 
-import Prelude (Unit, pure, unit)
 import Mantine.Core.Prelude
 
 modal :: (ModalProps -> ModalProps) -> JSX

--- a/src/Mantine/Core/Overlays/Modal.purs
+++ b/src/Mantine/Core/Overlays/Modal.purs
@@ -5,7 +5,7 @@ module Mantine.Core.Overlays.Modal
   , ModalOverflow(..)
   ) where
 
-import Prelude
+import Prelude (Unit, pure, unit)
 import Mantine.Core.Prelude
 
 modal :: (ModalProps -> ModalProps) -> JSX
@@ -52,40 +52,20 @@ type ModalProps =
 defaultModalProps :: ModalProps
 defaultModalProps =
   defaultThemingProps
-    { children:                  []
-    , centered:                  false
-    , closeButtonLabel:          Nothing
-    , closeOnClickOutside:       true
-    , closeOnEscape:             true
-    , exitTransitionDuration:    Nothing
-    , fullScreen:                false
-    , id:                        Nothing
-    , lockScroll:                true
-    , onClose:                   (pure unit)
-    , opened:                    false
-    , overflow:                  ModalOverflowInside
-    , overlayBlur:               Nothing
-    , overlayColor:              Nothing
-    , overlayOpacity:            Nothing
-    , padding:                   Nothing
-    , radius:                    Nothing
-    -- , shadow -- TODO
-    , size:                      Nothing
-    -- , target -- TODO
-    , title:                     Nothing
-    , transition:                Nothing
-    , transitionDuration:        Nothing
-    , transitionTimingFunction:  Nothing
-    , trapFocus:                 false
-    , withCloseButton:           true
-    , withFocusReturn:           true
-    , withinPortal:              true
-    , zIndex:                    Nothing
+    { closeOnClickOutside: true
+    , closeOnEscape:       true
+    , lockScroll:          true
+    , onClose:             pure unit
+    , withCloseButton:     true
+    , withFocusReturn:     true
+    , withinPortal:        true
     }
 
 data ModalOverflow
   = ModalOverflowInside
   | ModalOverflowOutside
+
+instance DefaultValue ModalOverflow where defaultValue = ModalOverflowInside
 
 instance ToFFI ModalOverflow String where
   toNative = case _ of

--- a/src/Mantine/Core/Overlays/Tooltip.purs
+++ b/src/Mantine/Core/Overlays/Tooltip.purs
@@ -15,7 +15,6 @@ module Mantine.Core.Overlays.Tooltip
   , TooltipGroupRow
   ) where
 
-import Prelude (Unit, const, mempty, pure, unit)
 import Mantine.Core.Prelude
 import React.Basic.DOM as DOM
 

--- a/src/Mantine/Core/Overlays/Tooltip.purs
+++ b/src/Mantine/Core/Overlays/Tooltip.purs
@@ -15,7 +15,7 @@ module Mantine.Core.Overlays.Tooltip
   , TooltipGroupRow
   ) where
 
-import Prelude
+import Prelude (Unit, const, mempty, pure, unit)
 import Mantine.Core.Prelude
 import React.Basic.DOM as DOM
 
@@ -96,11 +96,11 @@ type TooltipFloatingProps =
 defaultTooltipFloatingProps :: TooltipFloatingProps
 defaultTooltipFloatingProps =
   defaultThemingProps
-    { children:      mempty :: JSX
-    , offset:        10.0
-    , position:      TooltipPositionRight
-    , withinPortal:  true
-    } `union` defaultValue
+    { children:     mempty :: JSX
+    , offset:       10.0
+    , position:     TooltipPositionRight
+    , withinPortal: true
+    }
 
 defaultTooltipProps :: TooltipProps
 defaultTooltipProps =
@@ -116,7 +116,7 @@ defaultTooltipProps =
     , position:         TooltipPositionTop
     , transition:       TransitionFade
     , width:            pure (Dimension "auto")
-    } `union` defaultValue
+    }
 
 type TooltipPropsImpl = ThemingPropsImpl (TooltipPropsBaseImplRow + TooltipPropsImplRow)
 

--- a/src/Mantine/Core/Prelude.purs
+++ b/src/Mantine/Core/Prelude.purs
@@ -20,7 +20,7 @@ module Mantine.Core.Prelude
   , module Untagged.Union
   ) where
 
-import Prelude (Unit, identity, pure, unit, ($), (<<<))
+import Prelude (Unit, const, identity, map, mempty, pure, unit, ($), (=<<), (<<<), (>>>), (<$), (<$>))
 import Data.Default (class DefaultValue, defaultValue)
 import Data.Either (Either, either)
 import Data.Maybe (Maybe(..))

--- a/src/Mantine/Core/Typography/Table.purs
+++ b/src/Mantine/Core/Typography/Table.purs
@@ -34,7 +34,7 @@ defaultTableProps =
     { horizontalSpacing: Preset ExtraSmall
     , fontSize:          Preset Small
     , verticalSpacing:   Custom 7.0
-    } `union` defaultValue
+    }
 
 data TableCaptionSide
   = TableCaptionSideBottom


### PR DESCRIPTION
- Simplify defaultThemingProps helper. Default values are set by the helper now.
- `Mantine.Core.Prelude` reexports main features from `Prelude`, making the later one almost always irrelevant (less imports).